### PR TITLE
Compare with common ancestor instead of tip

### DIFF
--- a/src/main/java/de/ck35/maven/plugins/jacoco/JacocoReportChangesMojo.java
+++ b/src/main/java/de/ck35/maven/plugins/jacoco/JacocoReportChangesMojo.java
@@ -259,7 +259,7 @@ public class JacocoReportChangesMojo extends ReportMojo {
 	 * @throws IOException If process creation failed.
 	 */
 	protected Process gitDiffProcess(String branchName) throws IOException {
-		return new ProcessBuilder(Arrays.asList("git", "diff", "--name-only", branchName)).start();
+		return new ProcessBuilder(Arrays.asList("git", "diff", "--name-only", branchName+"...")).start();
 	}
 	
 	@Override


### PR DESCRIPTION
This should fix #2.
As described in http://git-scm.com/docs/git-diff this form compares to the common ancestor.
So it should not include changes only on the parent branch.
We should still make sure that it does not exclude wanted changes when several common ancestors exist.
